### PR TITLE
[FTK-1129] Rename reserved word String -> ZendString

### DIFF
--- a/library/ZendPdf/BinaryParser/DataSource/CString.php
+++ b/library/ZendPdf/BinaryParser/DataSource/CString.php
@@ -20,7 +20,7 @@ use ZendPdf\Exception;
  * @package    Zend_PDF
  * @subpackage Zend_PDF_BinaryParser
  */
-class String extends AbstractDataSource
+class CString extends AbstractDataSource
 {
     /**** Instance Variables ****/
 

--- a/library/ZendPdf/BinaryParser/DataSource/ZendString.php
+++ b/library/ZendPdf/BinaryParser/DataSource/ZendString.php
@@ -20,7 +20,7 @@ use ZendPdf\Exception;
  * @package    Zend_PDF
  * @subpackage Zend_PDF_BinaryParser
  */
-class CString extends AbstractDataSource
+class ZendString extends AbstractDataSource
 {
     /**** Instance Variables ****/
 

--- a/tests/ZendPdf/InternalType/BinaryStringTest.php
+++ b/tests/ZendPdf/InternalType/BinaryStringTest.php
@@ -8,7 +8,7 @@
  * @package   Zend_Pdf
  */
 
-namespace ZendPdfTest\InternalType\String;
+namespace ZendPdfTest\InternalType\CString;
 
 use ZendPdf\InternalType;
 

--- a/tests/ZendPdf/InternalType/BinaryStringTest.php
+++ b/tests/ZendPdf/InternalType/BinaryStringTest.php
@@ -8,7 +8,7 @@
  * @package   Zend_Pdf
  */
 
-namespace ZendPdfTest\InternalType\CString;
+namespace ZendPdfTest\InternalType\ZendString;
 
 use ZendPdf\InternalType;
 

--- a/tests/ZendPdf/InternalType/StreamObjectTest.php
+++ b/tests/ZendPdf/InternalType/StreamObjectTest.php
@@ -8,7 +8,7 @@
  * @package   Zend_Pdf
  */
 
-namespace ZendPdfTest\InternalType\Object;
+namespace ZendPdfTest\InternalType\CObject;
 
 use ZendPdf\InternalType;
 use ZendPdf\ObjectFactory;

--- a/tests/ZendPdf/InternalType/StreamObjectTest.php
+++ b/tests/ZendPdf/InternalType/StreamObjectTest.php
@@ -8,7 +8,7 @@
  * @package   Zend_Pdf
  */
 
-namespace ZendPdfTest\InternalType\CObject;
+namespace ZendPdfTest\InternalType\ZendObject;
 
 use ZendPdf\InternalType;
 use ZendPdf\ObjectFactory;


### PR DESCRIPTION
Having the reserved work `String` as part of the namespace is not allowed as of PHP 7.2. This PR is renaming it to `CString`.